### PR TITLE
#20 Fixed _preprocess_circuit  behavior to prevent input modification

### DIFF
--- a/src/quantum_gates/_legacy/simulator.py
+++ b/src/quantum_gates/_legacy/simulator.py
@@ -53,8 +53,8 @@ class LegacyMrAndersonSimulator:
         """
         # Prepare variables
         nqubit = len(qubits_layout)
-        t_qiskit_circ = qiskit_circ
-        raw_data = t_qiskit_circ.data
+        t_qiskit_circ = qiskit_circ.copy()
+        raw_data = [gate for gate in t_qiskit_circ.data]
         data = []
         prop = backend.properties()
         tm = prop.readout_length(0)

--- a/src/quantum_gates/_simulation/simulator.py
+++ b/src/quantum_gates/_simulation/simulator.py
@@ -202,7 +202,8 @@ class MrAndersonSimulator(object):
         data = []
         data_measure = []
         swap_detector = [a for a in range(nqubit)]
-        raw_data = t_qiskit_circ.data
+        raw_data = [gate for gate in t_qiskit_circ.data]  # Creates a shallow copy
+
 
         for i in range(t_qiskit_circ.__len__()):
             if raw_data[i].operation.name == 'ecr':


### PR DESCRIPTION
This fixes the behavior of the `_preprocess_circuit` method in the simulator.
Changes made : 
1. Ensures the input circuit (`t_qiskit_circ`) is not modified during preprocessing.
2. Introduced proper handling of `raw_data` to avoid in-place changes.
