### PR TITLE
[simulator] Fix bug coming from the qubit mapping.

### DIFF
--- a/src/quantum_gates/_simulation/simulator.py
+++ b/src/quantum_gates/_simulation/simulator.py
@@ -533,32 +533,32 @@ def _apply_gates_on_circuit(
             if data[j].operation.name == 'sx':
                 q_r = data[j].qubits[0]._index # Real qubit
                 q_v = qubit_layout.index(q_r) # Virtual qubit
-                circ.SX(q_v, p[q_r], T1[q_r], T2[q_r])
-                        
+                circ.SX(q_v, p[q_v], T1[q_v], T2[q_v])
+
             if data[j].operation.name == 'x':
                 q_r = data[j].qubits[0]._index # Real qubit
                 q_v = qubit_layout.index(q_r) # Virtual qubit
-                circ.X(q_v, p[q_r], T1[q_r], T2[q_r])
-                        
+                circ.X(q_v, p[q_v], T1[q_v], T2[q_v])
+
             if data[j].operation.name == 'ecr':
                 q_ctr_r = data[j].qubits[0]._index # Index control real qubit
                 q_trg_r = data[j].qubits[1]._index # Index target real qubit
                 q_ctr_v = qubit_layout.index(q_ctr_r) # Index control virtual qubit
-                q_trg_v = qubit_layout.index(q_trg_r) # Index control virtual qubit
-                circ.ECR(q_ctr_v, q_trg_v, t_int[q_ctr_r][q_trg_r], p_int[q_ctr_r][q_trg_r], p[q_ctr_r], p[q_trg_r], T1[q_ctr_r], T2[q_ctr_r], T1[q_trg_r], T2[q_trg_r])
+                q_trg_v = qubit_layout.index(q_trg_r) # Index target virtual qubit
+                circ.ECR(q_ctr_v, q_trg_v, t_int[q_ctr_r][q_trg_r], p_int[q_ctr_r][q_trg_r], p[q_ctr_v], p[q_trg_v], T1[q_ctr_v], T2[q_ctr_v], T1[q_trg_v], T2[q_trg_v])
 
             if data[j].operation.name == 'cx':
                 q_ctr_r = data[j].qubits[0]._index # Index control real qubit
                 q_trg_r = data[j].qubits[1]._index # Index target real qubit
                 q_ctr_v = qubit_layout.index(q_ctr_r) # Index control virtual qubit
-                q_trg_v = qubit_layout.index(q_trg_r) # Index control virtual qubit
-                circ.CNOT(q_ctr_v, q_trg_v, t_int[q_ctr_r][q_trg_r], p_int[q_ctr_r][q_trg_r], p[q_ctr_r], p[q_trg_r], T1[q_ctr_r], T2[q_ctr_r], T1[q_trg_r], T2[q_trg_r])
-            
+                q_trg_v = qubit_layout.index(q_trg_r) # Index target virtual qubit
+                circ.CNOT(q_ctr_v, q_trg_v, t_int[q_ctr_r][q_trg_r], p_int[q_ctr_r][q_trg_r], p[q_ctr_v], p[q_trg_v], T1[q_ctr_v], T2[q_ctr_v], T1[q_trg_v], T2[q_trg_v])
+
             if data[j].operation.name == 'delay':
                 q_r = data[j].qubits[0]._index # Real qubit
                 q_v = qubit_layout.index(q_r) # Virtual qubit
                 time = data[j].operation.duration * dt
-                circ.relaxation(q_v, time, T1[q_r], T2[q_r])              
+                circ.relaxation(q_v, time, T1[q_v], T2[q_v])              
 
         return
 
@@ -569,53 +569,61 @@ def _apply_gates_on_circuit(
 
             if data[j].operation.name == 'rz':
                 theta = float(data[j].operation.params[0])
-                q = data[j].qubits[0]._index
-                circ.Rz(q, theta)
+                q_r = data[j].qubits[0]._index
+                q_v = qubit_layout.index(q_r)
+                circ.Rz(q_v, theta)
 
             if data[j].operation.name == 'sx':
-                q = data[j].qubits[0]._index
+                q_r = data[j].qubits[0]._index
+                q_v = qubit_layout.index(q_r)
                 for k in range(nqubit):
-                    if k == q:
-                        circ.SX(k, p[k], T1[k], T2[q])
+                    if k == q_v:
+                        circ.SX(k, p[q_v], T1[q_v], T2[q_v])
                     else:
                         circ.I(k)
 
             if data[j].operation.name == 'x':
-                q = data[j].qubits[0]._index
+                q_r = data[j].qubits[0]._index
+                q_v = qubit_layout.index(q_r)
                 for k in range(nqubit):
-                    if k == q:
-                        circ.X(k, p[k], T1[k], T2[q])
+                    if k == q_v:
+                        circ.X(k, p[q_v], T1[q_v], T2[q_v])
                     else:
                         circ.I(k)
 
             if data[j].operation.name == 'ecr':
-                q_ctr = data[j].qubits[0]._index # index control qubit
-                q_trg = data[j].qubits[1]._index # index target qubit
+                q_ctr_r = data[j].qubits[0]._index # index control real qubit
+                q_trg_r = data[j].qubits[1]._index # index target real qubit
+                q_ctr_v = qubit_layout.index(q_ctr_r)
+                q_trg_v = qubit_layout.index(q_trg_r)
                 for k in range(nqubit):
-                    if k == q_ctr:
-                        circ.ECR(k, q_trg, t_int[k][q_trg], p_int[k][q_trg], p[k], p[q_trg], T1[k], T2[k], T1[q_trg], T2[q_trg])
-                    elif k == q_trg:
+                    if k == q_ctr_v:
+                        circ.ECR(k, q_trg_v, t_int[q_ctr_r][q_trg_r], p_int[q_ctr_r][q_trg_r], p[q_ctr_v], p[q_trg_v], T1[q_ctr_v], T2[q_ctr_v], T1[q_trg_v], T2[q_trg_v])
+                    elif k == q_trg_v:
                         pass
                     else:
                         circ.I(k)
 
             if data[j].operation.name == 'cx':
-                q_ctr = data[j].qubits[0]._index # index control qubit
-                q_trg = data[j].qubits[1]._index # index target qubit
+                q_ctr_r = data[j].qubits[0]._index # index control real qubit
+                q_trg_r = data[j].qubits[1]._index # index target real qubit
+                q_ctr_v = qubit_layout.index(q_ctr_r)
+                q_trg_v = qubit_layout.index(q_trg_r)
                 for k in range(nqubit):
-                    if k == q_ctr:
-                        circ.CNOT(k, q_trg, t_int[k][q_trg], p_int[k][q_trg], p[k], p[q_trg], T1[k], T2[k], T1[q_trg], T2[q_trg])
-                    elif k == q_trg:
+                    if k == q_ctr_v:
+                        circ.CNOT(k, q_trg_v, t_int[q_ctr_r][q_trg_r], p_int[q_ctr_r][q_trg_r], p[q_ctr_v], p[q_trg_v], T1[q_ctr_v], T2[q_ctr_v], T1[q_trg_v], T2[q_trg_v])
+                    elif k == q_trg_v:
                         pass
                     else:
                         circ.I(k)
-            
+
             if data[j].operation.name == 'delay':
-                q = data[j].qubits[0]._index
+                q_r = data[j].qubits[0]._index
+                q_v = qubit_layout.index(q_r)
                 time = data[j].operation.duration * dt
                 for k in range(nqubit):
-                    if k == q:
-                        circ.relaxation(k, time, T1[k], T2[k])
+                    if k == q_v:
+                        circ.relaxation(k, time, T1[q_v], T2[q_v])
                     else:
                         circ.I(k)
 
@@ -687,18 +695,17 @@ def _single_shot(args: dict) -> np.array:
                     qubit_list=qubits_v,
                     cbit_list=None,
                 )
-
-                # Extract noise params *once*
                 T1, T2, p = device_param["T1"], device_param["T2"], device_param["p"]
 
-                # Apply X/I layer
+                # Apply X/I layer, map physical to virtual indices
                 touched = set()
                 for q, res in zip(qubits, outcomes):
-                    touched.add(q)
+                    q_v = qubit_layout.index(q)
+                    touched.add(q_v)
                     if res == 1:
-                        circ.X(i=q, p=p[q], T1=T1[q], T2=T2[q])
+                        circ.X(i=q_v, p=p[q_v], T1=T1[q_v], T2=T2[q_v])
                     else:
-                        circ.I(i=q)
+                        circ.I(i=q_v)
 
                 for k in range(circ.nqubit):
                     if k not in touched:
@@ -706,7 +713,7 @@ def _single_shot(args: dict) -> np.array:
 
                 # Apply layer to state and reset builder
                 psi = circ.statevector(psi)
-                circ.reset(phase_reset=False)  # Reset internal state for next chunk
+                circ.reset(phase_reset=False)
 
             else:
                 op_name = d.operation.name

--- a/tests/gates/test_noise_scaling.py
+++ b/tests/gates/test_noise_scaling.py
@@ -7,9 +7,9 @@ from qiskit_aer import AerSimulator
 from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 from qiskit.circuit.controlflow import ControlFlowOp
 
-from quantum_gates._simulation.circuit import EfficientCircuit, BinaryCircuit
 from src.quantum_gates.utilities import DeviceParameters
-from quantum_gates.simulators import MrAndersonSimulator
+from src.quantum_gates.simulators import MrAndersonSimulator
+from src.quantum_gates.circuits import EfficientCircuit, BinaryCircuit
 
 from src.quantum_gates.gates import (
     ScaledNoiseGates,
@@ -998,14 +998,11 @@ def test_efficient_circuit_sparse_layout_rz_index_error():
         )
 
 
-def test_binary_circuit_sparse_layout_noise_param_indexing():
-    """BUG: BinaryCircuit indexes noise params by physical qubit, not layout position.
+def test_binary_circuit_sparse_layout_works():
+    """BinaryCircuit should work correctly with sparse layouts.
 
-    BinaryCircuit correctly maps physical→virtual for circuit operations via
-    qubit_layout.index(), but accesses noise params as p[q_r] where q_r is
-    the physical qubit index. Since DeviceParameters stores T1, T2, p as
-    lists indexed by layout position (0, 1, ..., n-1), p[10] raises
-    IndexError when the layout is [10, 11] (p only has 2 elements).
+    After fixing noise param indexing (p[q_v] instead of p[q_r]),
+    BinaryCircuit correctly handles sparse layouts like [10, 11].
 
     Relates to GitHub issue #39.
     """
@@ -1032,15 +1029,18 @@ def test_binary_circuit_sparse_layout_noise_param_indexing():
 
     sim = MrAndersonSimulator(gates=gates, CircuitClass=BinaryCircuit)
 
-    # BinaryCircuit uses p[q_r] where q_r=10, but p only has 2 elements
-    with pytest.raises(IndexError):
-        sim.run(
-            t_qiskit_circ=t_circ,
-            psi0=zero_state(nqubit),
-            shots=shots,
-            device_param=device_param,
-            nqubit=nqubit,
-        )
+    res = sim.run(
+        t_qiskit_circ=t_circ,
+        psi0=zero_state(nqubit),
+        shots=shots,
+        device_param=device_param,
+        nqubit=nqubit,
+    )
+
+    counts = res["mid_counts"]
+    assert counts.get("11", 0) == shots, (
+        f"Expected '11' for all {shots} shots but got {counts}"
+    )
 
 
 def test_pickle_scaled_noise():


### PR DESCRIPTION
Problem:

- As we documented in [this commit ](https://github.com/CERN-QTI/quantum-gates/pull/50/changes/e42c6949d9ddba3388207a55d7da21e9534e86aa), the _apply_gates_on_circuit method had a bug for the path that is used for the EfficientCircuit. The code path used raw physical qubit indices from the transpiled circuit without mapping them to virtual indices
- This caused gates to be silently dropped or applied to the wrong qubit when the transpiler's physical layout didn't match the identity mapping [0, 1, ..., n-1].
- Moreover, the noise parameters (p, T1, T2) were indexed by physical qubit (p[q_r]) instead of layout position (p[q_v]), which would crash with IndexError on sparse layouts.

Solution:

- For the EfficientCircuit path we added q_v = qubit_layout.index(q_r) mapping for all gate types, adopting the technique already used in the BinaryCircuit path.
- For the BinaryCircuit path we fixed noise parameter indexing from p[q_r] to p[q_v].

Note:
- The original observation that the two tests (see comments of PR 50) failed in my case was probably because depending on the Qiskit version the logical layout is not equal to the physical one (that can cause the bug to show).