### PR TITLE
Automated the release process with Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/quantum-gates
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify version matches tag
+        run: |
+          PKG_VERSION=$(python -c "import configparser, pathlib; \
+            p = configparser.ConfigParser(); \
+            p.read_string(pathlib.Path('setup.cfg').read_text()); \
+            print(p['metadata']['version'])")
+          TAG_VERSION="${GITHUB_REF_NAME#release-}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: setup.cfg=$PKG_VERSION, tag=$TAG_VERSION"
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -379,6 +379,63 @@ Build the wheel with the command `python3 -m build --sdist --wheel .` and naviga
 Use `ls` to display the name of the wheel, and run `pip install <filename>.whl` with the correct filename. 
 Now you can use your version of the library. 
 
+## Release process
+
+Releases are published to PyPI automatically when a GitHub Release is published.
+The workflow lives at [`.github/workflows/publish.yml`](.github/workflows/publish.yml)
+and uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via identity federation.
+
+Steps for a maintainer cutting a new release (using `2.4.0` as the example):
+
+1. Bump the version on `main` in both `setup.py` and `setup.cfg`, the values must
+   match. Open a PR titled `[release] Bump version to 2.4.0` and merge.
+
+2. Sanity-check the build locally:
+
+   ```bash
+   python -m build
+   twine check dist/*
+   ```
+
+3. Tag the release commit with the `release-X.Y.Z` format and push the tag:
+
+   ```bash
+   git tag release-2.4.0
+   git push origin release-2.4.0
+   ```
+
+4. Draft the GitHub release:
+   - Open https://github.com/CERN-QTI/quantum-gates/releases/new.
+   - Select tag `release-2.4.0`.
+   - Title: `Release quantum-gates v2.4.0`.
+   - Body: high-level bullet points grouped under `New features`,
+     `Breaking changes`, and `Other`.
+
+5. Publish the release: 
+   This triggers the publish workflow, which builds the
+   sdist + wheel in a clean runner and uploads them to PyPI.
+
+6. Verify by checking https://pypi.org/project/quantum-gates/ and installing
+   the new version in a fresh virtualenv:
+
+   ```bash
+   python -m venv /tmp/qg-smoke && source /tmp/qg-smoke/bin/activate
+   pip install quantum-gates==2.4.0
+   python -c "from quantum_gates.gates import standard_gates; print('ok')"
+   ```
+
+If the workflow fails, fix the issue and re-run it from the GitHub Actions tab.
+
+Note that this workflow was setup by the maintainers with identity federation on PyPI. For future reference, it was
+setup under [this link](https://pypi.org/manage/project/quantum-gates/settings/publishing/) by adding a publisher with:
+
+- Owner: `CERN-QTI`
+- Repository: `quantum-gates`
+- Workflow name: `publish.yml`
+- Environment: `pypi`
+
+This workflow allows us to publish new version without having to manage any secrets.
+
 ## Building the documentation
 
 The documentation for Noisy Quantum Gates is built using Sphinx and is hosted on 


### PR DESCRIPTION
Before we did the release to PyPI locally using an access token. Now we switch this to identity federation so also other maintainers can do it without having to share any tokens.