### PR TITLE
Non consecutive two qubit gates

### DIFF
--- a/src/quantum_gates/_simulation/simulator.py
+++ b/src/quantum_gates/_simulation/simulator.py
@@ -11,7 +11,7 @@ from qiskit import QuantumCircuit
 from .._gates.gates import Gates, standard_gates
 from .._simulation.circuit import EfficientCircuit, BinaryCircuit
 from .._simulation.circuit import Circuit, StandardCircuit
-
+from .._utility.simulations_utility import permute_to_adjacent, permute_back
 
 class MrAndersonSimulator(object):
     """
@@ -368,6 +368,18 @@ class MrAndersonSimulator(object):
                 current_chunk.append(op)  # Also keep the rz in the chunk
             else:
                 # Normal operation (only if in layout)
+                # Check if this is a non-consecutive two-qubit gate
+                if len(q_idx) == 2:
+                    if abs(q_idx[0] - q_idx[1]) != 1:
+                        # Non-consecutive: flush current chunk first
+                        if current_chunk:
+                            data.append((current_chunk, 0))
+                            current_chunk = []
+                        # Flag as non-consecutive two-qubit gate
+                        data.append((op, 2))
+                        continue
+                
+                # Consecutive or single-qubit: normal path
                 current_chunk.append(op)
 
         # Flush final chunk if non-empty
@@ -755,7 +767,57 @@ def _single_shot(args: dict) -> np.array:
 
                 else:
                     raise ValueError(f"Unknown / not yet implemented gate: {op_name}")
+        
+        elif flag == 2:
+            n = circ.nqubit
+            # Unpack dict
+            T1, T2, p, rout, p_int, t_int, tm, dt = (
+                device_param["T1"],
+                device_param["T2"],
+                device_param["p"],
+                device_param["rout"],
+                device_param["p_int"],
+                device_param["t_int"],
+                device_param["tm"],
+                device_param["dt"][0]
+            )
+
+            q_ctr_r = d.qubits[0]._index
+            q_trg_r = d.qubits[1]._index
+            q_ctr_v = qubit_layout.index(q_ctr_r)
+            q_trg_v = qubit_layout.index(q_trg_r)
+            
+            # 1. Permute psi so the two qubits are adjacent
+            psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v, q_trg_v, n)
+            op_name = d.operation.name
+            # Apply gate at positions 0 and 1
+            if op_name == 'ecr':
+                circ.ECR(0, 1,
+                        t_int[q_ctr_r][q_trg_r],
+                        p_int[q_ctr_r][q_trg_r],
+                        p[q_ctr_v], p[q_trg_v],
+                        T1[q_ctr_v], T2[q_ctr_v],
+                        T1[q_trg_v], T2[q_trg_v])
+            elif op_name == 'cx':
+                circ.CNOT(0, 1,
+                        t_int[q_ctr_r][q_trg_r],
+                        p_int[q_ctr_r][q_trg_r],
+                        p[q_ctr_v], p[q_trg_v],
+                        T1[q_ctr_v], T2[q_ctr_v],
+                        T1[q_trg_v], T2[q_trg_v])
+            else:
+                raise ValueError(f"Unknown / not yet implemented gate: {op_name}")
+
+            # Identity on all remaining qubits
+            for k in range(2, n):
+                circ.I(k)
+            
+            psi_permuted = circ.statevector(psi_permuted)
+            circ.reset(phase_reset=False)
     
+            # 3. Permute psi back
+            psi = permute_back(psi_permuted, perm, n)
+            
     # Mid_measurement results in Qiskit clbit order
     qiskit_order_mid_results = mid_results[::-1]  
 

--- a/src/quantum_gates/_utility/simulations_utility.py
+++ b/src/quantum_gates/_utility/simulations_utility.py
@@ -601,3 +601,30 @@ def collapse_statevector(psi: np.ndarray, target_qubit: int, outcome: int, n: in
     collapse_mask = ((indices >> mask_pos) & 1) != outcome
     psi[collapse_mask] = 0.0
     return psi
+
+def permute_to_adjacent(psi: np.ndarray, q_ctr_v: int, q_trg_v: int, n: int) -> tuple[np.ndarray, list]:
+    """Permute psi so that q_ctr_v and q_trg_v are at positions 0 and 1.
+    Returns the permuted psi and the permutation used (needed to invert)."""
+    
+    # Build permutation: bring q_ctr_v to 0, q_trg_v to 1, rest in order
+    other = [k for k in range(n) if k != q_ctr_v and k != q_trg_v]
+    perm = [q_ctr_v, q_trg_v] + other
+    
+    # Reshape, transpose, reshape back
+    psi_tensor = psi.reshape([2] * n)
+    psi_tensor = np.transpose(psi_tensor, perm)
+    psi_permuted = psi_tensor.reshape(-1)
+    
+    return psi_permuted, perm
+
+
+def permute_back(psi: np.ndarray, perm: list, n: int) -> np.ndarray:
+    """Invert the permutation applied by permute_to_adjacent."""
+    
+    inv_perm = np.argsort(perm)
+    
+    psi_tensor = psi.reshape([2] * n)
+    psi_tensor = np.transpose(psi_tensor, inv_perm)
+    psi_back = psi_tensor.reshape(-1)
+    
+    return psi_back

--- a/src/quantum_gates/utilities.py
+++ b/src/quantum_gates/utilities.py
@@ -20,7 +20,9 @@ from ._utility.simulations_utility import (
     permute_qiskit_sv_to_logical,
     permute_normal_sv_to_logical_normal,
     compute_born_probability,
-    collapse_statevector
+    collapse_statevector, 
+    permute_to_adjacent, 
+    permute_back
     ) 
 
 from ._utility.circ_optimizer import Optimizer

--- a/tests/helpers/device_parameters.py
+++ b/tests/helpers/device_parameters.py
@@ -1,8 +1,9 @@
 from src.quantum_gates.utilities import DeviceParameters
+from tests.helpers.paths import device_parameters_path
 
 
 qubits_layout = [0, 1, 4, 7, 10, 12, 15, 18, 21, 23, 24, 25, 22, 19, 16, 14, 11, 8, 5, 3, 2]
-location = "tests/helpers/device_parameters/ibm_kyoto/"
+location = device_parameters_path("ibm_kyoto")
 device_param = DeviceParameters(qubits_layout=qubits_layout)
 device_param.load_from_texts(location)
 T1, T2, p, rout, p_int, t_int, tm, dt, metadata = device_param.get_as_tuple()

--- a/tests/helpers/paths.py
+++ b/tests/helpers/paths.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+
+
+def helper_path(*parts: str, trailing_slash: bool = False) -> str:
+    path = TESTS_DIR.joinpath("helpers", *parts)
+    path_str = str(path)
+    return f"{path_str}/" if trailing_slash else path_str
+
+
+def device_parameters_path(device_name: str) -> str:
+    return helper_path("device_parameters", device_name, trailing_slash=True)

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -9,20 +9,21 @@ from src.quantum_gates.circuits import EfficientCircuit
 from src.quantum_gates.gates import almost_noise_free_gates
 from src.quantum_gates.utilities import DeviceParameters
 
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 _backend = FakeBrisbane()
-_location = "tests/helpers/device_parameters/ibm_kyoto/"
-_LAYOUT = [0, 1, 2, 3, 4]
+coupling_map = _backend.coupling_map
+_LAYOUT = list(range(16))
 
 def _device_param(nqubits):
     dp = DeviceParameters(qubits_layout=_LAYOUT[:nqubits])
-    dp.load_from_texts(location=_location)
+    dp.load_from_backend(_backend)  # load from FakeBrisbane directly instead of text files
     return dp.__dict__()
 
 def run_consecutive(shots=100):
-    nqubits = 3
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.h(0)
-    qc.cx(0, 1)      # consecutive
+    qc.h(4)
+    qc.cx(4, 5)      # consecutive
     qc.measure(range(nqubits), range(nqubits))
     t_circ = transpile(qc, backend=_backend, initial_layout=_LAYOUT[:nqubits],
                        seed_transpiler=42, optimization_level=0)
@@ -32,11 +33,30 @@ def run_consecutive(shots=100):
     return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
                    device_param=_device_param(nqubits), nqubit=nqubits)
 
-def run_non_consecutive(shots=100):
-    nqubits = 3
+def run_non_consecutive_with_swaps(shots=100):
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.h(0)
-    qc.cx(0, 2)      # non-consecutive
+    qc.h(4)
+    qc.cx(4, 14)      # not directly connected — transpiler inserts SWAPs
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = transpile(qc, backend=_backend,
+                       initial_layout=_LAYOUT[:nqubits],
+                       seed_transpiler=42,
+                       optimization_level=0)
+    print("SWAP route ops:", t_circ.count_ops())
+
+    psi0 = np.zeros(2**nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=almost_noise_free_gates, CircuitClass=EfficientCircuit)
+    return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
+                   device_param=_device_param(nqubits), nqubit=nqubits)
+
+def run_non_consecutive(shots=100):
+    nqubits = 16
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(4)
+    qc.cx(4, 15)      # non-consecutive
     qc.measure(range(nqubits), range(nqubits))
     t_circ = transpile(qc, backend=_backend, initial_layout=_LAYOUT[:nqubits],
                        seed_transpiler=42, optimization_level=0)
@@ -55,6 +75,18 @@ if __name__ == "__main__":
     pr = cProfile.Profile()
     pr.enable()
     run_consecutive(shots=shots)
+    pr.disable()
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+    ps.print_stats(20)
+    print(s.getvalue())
+
+    print("=" * 60)
+    print(" NON-CONSECUTIVE GATE WITH SWAPPING")
+    print("=" * 60)
+    pr = cProfile.Profile()
+    pr.enable()
+    run_non_consecutive_with_swaps(shots=shots)
     pr.disable()
     s = io.StringIO()
     ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -5,7 +5,7 @@ import numpy as np
 from qiskit import QuantumCircuit, transpile
 from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 from src.quantum_gates.simulators import MrAndersonSimulator
-from src.quantum_gates.circuits import EfficientCircuit
+from src.quantum_gates.circuits import EfficientCircuit, BinaryCircuit
 from src.quantum_gates.gates import almost_noise_free_gates
 from src.quantum_gates.utilities import DeviceParameters
 
@@ -66,11 +66,42 @@ def run_non_consecutive(shots=100):
     return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
                    device_param=_device_param(nqubits), nqubit=nqubits)
 
+
+
+def run_consecutive_binary(shots=100):
+    nqubits = 16
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(4)
+    qc.cx(4, 5)
+    qc.measure(range(nqubits), range(nqubits))
+    t_circ = transpile(qc, backend=_backend, initial_layout=_LAYOUT[:nqubits],
+                       seed_transpiler=42, optimization_level=0)
+    psi0 = np.zeros(2**nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=almost_noise_free_gates, CircuitClass=BinaryCircuit)
+    return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
+                   device_param=_device_param(nqubits), nqubit=nqubits)
+
+def run_non_consecutive_binary(shots=100):
+    nqubits = 16
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(4)
+    qc.cx(4, 15)
+    qc.measure(range(nqubits), range(nqubits))
+    t_circ = transpile(qc, backend=_backend, initial_layout=_LAYOUT[:nqubits],
+                       seed_transpiler=42, optimization_level=0)
+    psi0 = np.zeros(2**nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=almost_noise_free_gates, CircuitClass=BinaryCircuit)
+    return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
+                   device_param=_device_param(nqubits), nqubit=nqubits)
+
+
 if __name__ == "__main__":
     shots = 100
 
     print("=" * 60)
-    print(" CONSECUTIVE GATE")
+    print(" CONSECUTIVE GATE - EFFICIENT CIRCUIT")
     print("=" * 60)
     pr = cProfile.Profile()
     pr.enable()
@@ -82,7 +113,7 @@ if __name__ == "__main__":
     print(s.getvalue())
 
     print("=" * 60)
-    print(" NON-CONSECUTIVE GATE WITH SWAPPING")
+    print(" NON-CONSECUTIVE GATE WITH SWAPPING - EFFICIENT CIRCUIT")
     print("=" * 60)
     pr = cProfile.Profile()
     pr.enable()
@@ -94,11 +125,35 @@ if __name__ == "__main__":
     print(s.getvalue())
 
     print("=" * 60)
-    print(" NON-CONSECUTIVE GATE")
+    print(" NON-CONSECUTIVE GATE - EFFICIENT CIRCUIT")
     print("=" * 60)
     pr = cProfile.Profile()
     pr.enable()
     run_non_consecutive(shots=shots)
+    pr.disable()
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+    ps.print_stats(20)
+    print(s.getvalue())
+
+    print("=" * 60)
+    print(" CONSECUTIVE GATE — BinaryCircuit")
+    print("=" * 60)
+    pr = cProfile.Profile()
+    pr.enable()
+    run_consecutive_binary(shots=shots)
+    pr.disable()
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+    ps.print_stats(20)
+    print(s.getvalue())
+
+    print("=" * 60)
+    print(" NON-CONSECUTIVE GATE — BinaryCircuit")
+    print("=" * 60)
+    pr = cProfile.Profile()
+    pr.enable()
+    run_non_consecutive_binary(shots=shots)
     pr.disable()
     s = io.StringIO()
     ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -1,0 +1,74 @@
+import cProfile
+import pstats
+import io
+import numpy as np
+from qiskit import QuantumCircuit, transpile
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
+from src.quantum_gates.simulators import MrAndersonSimulator
+from src.quantum_gates.circuits import EfficientCircuit
+from src.quantum_gates.gates import almost_noise_free_gates
+from src.quantum_gates.utilities import DeviceParameters
+
+_backend = FakeBrisbane()
+_location = "tests/helpers/device_parameters/ibm_kyoto/"
+_LAYOUT = [0, 1, 2, 3, 4]
+
+def _device_param(nqubits):
+    dp = DeviceParameters(qubits_layout=_LAYOUT[:nqubits])
+    dp.load_from_texts(location=_location)
+    return dp.__dict__()
+
+def run_consecutive(shots=100):
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 1)      # consecutive
+    qc.measure(range(nqubits), range(nqubits))
+    t_circ = transpile(qc, backend=_backend, initial_layout=_LAYOUT[:nqubits],
+                       seed_transpiler=42, optimization_level=0)
+    psi0 = np.zeros(2**nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=almost_noise_free_gates, CircuitClass=EfficientCircuit)
+    return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
+                   device_param=_device_param(nqubits), nqubit=nqubits)
+
+def run_non_consecutive(shots=100):
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 2)      # non-consecutive
+    qc.measure(range(nqubits), range(nqubits))
+    t_circ = transpile(qc, backend=_backend, initial_layout=_LAYOUT[:nqubits],
+                       seed_transpiler=42, optimization_level=0)
+    psi0 = np.zeros(2**nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=almost_noise_free_gates, CircuitClass=EfficientCircuit)
+    return sim.run(t_qiskit_circ=t_circ, psi0=psi0, shots=shots,
+                   device_param=_device_param(nqubits), nqubit=nqubits)
+
+if __name__ == "__main__":
+    shots = 100
+
+    print("=" * 60)
+    print(" CONSECUTIVE GATE")
+    print("=" * 60)
+    pr = cProfile.Profile()
+    pr.enable()
+    run_consecutive(shots=shots)
+    pr.disable()
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+    ps.print_stats(20)
+    print(s.getvalue())
+
+    print("=" * 60)
+    print(" NON-CONSECUTIVE GATE")
+    print("=" * 60)
+    pr = cProfile.Profile()
+    pr.enable()
+    run_non_consecutive(shots=shots)
+    pr.disable()
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+    ps.print_stats(20)
+    print(s.getvalue())

--- a/tests/simulation/test_AER_vs_simulator.py
+++ b/tests/simulation/test_AER_vs_simulator.py
@@ -1,0 +1,273 @@
+import pytest
+import numpy as np
+from qiskit import QuantumCircuit, transpile
+from qiskit_aer import AerSimulator
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
+from src.quantum_gates.simulators import MrAndersonSimulator
+from src.quantum_gates.circuits import EfficientCircuit, BinaryCircuit
+from src.quantum_gates.gates import almost_noise_free_gates
+from src.quantum_gates.utilities import DeviceParameters
+
+_backend = FakeBrisbane()
+_LAYOUT = list(range(5))
+
+def _device_param(nqubits):
+    dp = DeviceParameters(qubits_layout=_LAYOUT[:nqubits])
+    dp.load_from_backend(_backend)
+    return dp.__dict__()
+
+def _transpile_mr_anderson(circ, nqubits):
+    return transpile(
+        circ,
+        backend=_backend,
+        initial_layout=_LAYOUT[:nqubits],
+        seed_transpiler=42,
+        optimization_level=0,
+    )
+
+def _run_mr_anderson(t_circ, nqubits, circuit_class, shots=500):
+    psi0 = np.zeros(2**nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=almost_noise_free_gates, CircuitClass=circuit_class)
+    result = sim.run(
+        t_qiskit_circ=t_circ,
+        psi0=psi0,
+        shots=shots,
+        device_param=_device_param(nqubits),
+        nqubit=nqubits,
+    )
+    return result["probs"]
+
+def _run_aer(circ, shots=2000):
+    sim = AerSimulator()
+    t_circ = transpile(circ, sim)
+    result = sim.run(t_circ, shots=shots).result()
+    counts = result.get_counts()
+    total = sum(counts.values())
+    return {k: v/total for k, v in counts.items()}
+
+def _dominant_outcomes(probs, threshold=0.05):
+    return {k for k, v in probs.items() if v > threshold}
+
+def _assert_matches_aer(qc, nqubits, circuit_class, shots_mr=500, shots_aer=2000):
+    t_circ = _transpile_mr_anderson(qc, nqubits)
+    mr_probs  = _run_mr_anderson(t_circ, nqubits, circuit_class, shots=shots_mr)
+    aer_probs = _run_aer(qc, shots=shots_aer)
+    mr_dominant  = _dominant_outcomes(mr_probs)
+    aer_dominant = _dominant_outcomes(aer_probs)
+    assert mr_dominant == aer_dominant, (
+        f"MrAnderson dominant outcomes {mr_dominant} do not match "
+        f"AER dominant outcomes {aer_dominant}"
+    )
+
+# ── Single qubit gates ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_x_gate(circuit_class):
+    """X gate on qubit 0 should flip |0> to |1>."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_hadamard(circuit_class):
+    """H gate should produce equal superposition."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_x_on_all_qubits(circuit_class):
+    """X on all qubits should flip entire register."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    for q in range(nqubits):
+        qc.x(q)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_rz_gate(circuit_class):
+    """RZ gate followed by measurement in Z basis should leave |0> unchanged."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.rz(np.pi / 4, 0)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+# ── Two qubit gates ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_cnot_flips_target(circuit_class):
+    """CNOT with control |1> should flip target."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)
+    qc.cx(0, 1)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_cnot_control_zero(circuit_class):
+    """CNOT with control |0> should leave state unchanged."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.cx(0, 1)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_bell_state(circuit_class):
+    """H + CNOT should produce Bell state."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_ghz_state(circuit_class):
+    """H + chain of CNOTs should produce GHZ state."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+# ── Mid-circuit measurements ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_mid_measurement_zero_state(circuit_class):
+    """Mid-circuit measurement on |0> should always read 0."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits + 1)
+    qc.measure(0, nqubits)
+    qc.barrier()
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_mid_measurement_after_x(circuit_class):
+    """Mid-circuit measurement after X gate should always read 1."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits + 1)
+    qc.x(0)
+    qc.measure(0, nqubits)
+    qc.barrier()
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+# ── Reset ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_reset_after_x(circuit_class):
+    """Reset after X gate should return qubit to |0>."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)
+    qc.reset(0)
+    qc.barrier()
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_reset_bell_state(circuit_class):
+    """Reset one qubit of a Bell state should leave the other in a mixed state."""
+    nqubits = 2
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.reset(0)
+    qc.barrier()
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+# ── Deeper circuits ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_alternating_x_cnot(circuit_class):
+    """Alternating X and CNOT gates across multiple qubits."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)
+    qc.cx(0, 1)
+    qc.x(2)
+    qc.cx(1, 2)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_hadamard_on_all_qubits(circuit_class):
+    """H on all qubits produces uniform superposition."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    for q in range(nqubits):
+        qc.h(q)
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_aer_match_multi_cycle_stabilizer(circuit_class):
+    """Multi-cycle stabilizer-like circuit with resets and mid-measurements."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits + 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure(1, nqubits)
+    qc.reset(1)
+    qc.cx(0, 1)
+    qc.measure(1, nqubits + 1)
+    qc.barrier()
+    qc.measure(range(nqubits), range(nqubits))
+    #Just to make sure the measurement is actually a mid-circuit measurement and not just at the end
+    
+    _assert_matches_aer(qc, nqubits, circuit_class)

--- a/tests/simulation/test_AER_vs_simulator.py
+++ b/tests/simulation/test_AER_vs_simulator.py
@@ -36,7 +36,9 @@ def _run_mr_anderson(t_circ, nqubits, circuit_class, shots=500):
         device_param=_device_param(nqubits),
         nqubit=nqubits,
     )
-    return result["probs"]
+    counts = result["mid_counts"]
+    total = sum(counts.values())
+    return {k: v/total for k, v in counts.items()}
 
 def _run_aer(circ, shots=2000):
     sim = AerSimulator()

--- a/tests/simulation/test_anderson_simulator.py
+++ b/tests/simulation/test_anderson_simulator.py
@@ -12,10 +12,11 @@ from src.quantum_gates.gates import standard_gates, noise_free_gates
 from src.quantum_gates._gates.gates import numerical_gates, almost_noise_free_gates
 from src.quantum_gates.utilities import DeviceParameters
 import tests.helpers.functions as helper_functions
+from tests.helpers.paths import device_parameters_path
 from qiskit_ibm_runtime.fake_provider import FakeBrisbane
 
 
-location = f"tests/helpers/device_parameters/ibm_kyoto/"
+location = device_parameters_path("ibm_kyoto")
 
 backend = setup_backend(device_name=FakeBrisbane(), use_fake=True)
 
@@ -309,7 +310,7 @@ def test_simulator_speed_for_more_efficient_circuits(nqubits, times):
         "shots": 1,
         "nqubits": nqubits,
         "qubits_layout": [0, 1, 2, 3, 4],
-        "location_device_parameters": "tests/helpers/device_parameters/ibm_kyoto/",
+        "location_device_parameters": location,
         "backend": backend,
         "do_simulation": do_simulation,
         "gates": almost_noise_free_gates,
@@ -355,7 +356,7 @@ def test_simulator_speed_for_efficient_circuit(nqubits, times):
         "shots": 1,
         "nqubits": nqubits,
         "qubits_layout": [0, 1, 4, 7, 10, 12, 15, 18, 21, 23, 24, 25, 22, 19, 16, 14, 11, 8, 5, 3, 2],
-        "location_device_parameters": "tests/helpers/device_parameters/ibm_kyoto/"
+        "location_device_parameters": location
     }
 
     time_efficient_circuit = 0
@@ -385,7 +386,7 @@ def test_simulation_speed_parallel_vs_sequential(nqubits):
         "shots": shots,
         "nqubits": nqubits,
         "qubits_layout": [0, 1, 2, 3, 4],
-        "location_device_parameters": "tests/helpers/device_parameters/ibm_kyoto/"
+        "location_device_parameters": location
     }
 
     # Parallel

--- a/tests/simulation/test_mid_circuit.py
+++ b/tests/simulation/test_mid_circuit.py
@@ -659,9 +659,9 @@ def test_array_mid_measure_deterministic_parametrized(
             f"Expected grouped mid outcomes {expected_mid}, got {grouped}"
         )
 
-    probs = result["probs"]
+    probs = result["mid_counts"]
     assert probs.get(expected_final, 0.0) > 0.95, (
-        f"Expected final state |{expected_final}> but got probs={probs}"
+        f"Expected final state |{expected_final}> but got probs={probs} \n probs.get('{expected_final}', 0.0)={probs.get(expected_final, 0.0):.4f}"
     )
 
 
@@ -781,40 +781,6 @@ def _group_mid_events_by_round(mid_events, nqubits, n_mid, n_rounds):
         grouped.append([int(event["outcome"][0]) for event in round_events])
 
     return grouped
-
-
-def _deterministic_array_mid_measure_circuit(nqubits, init_ones, measure_qubits, n_rounds=1):
-    """Build deterministic circuits with array-style mid-circuit measurements.
-
-    Each round measures `measure_qubits` using one array-style qc.measure(...) call.
-    """
-    n_mid = len(measure_qubits)
-    n_clbits = nqubits + n_rounds * n_mid
-    qc = QuantumCircuit(nqubits, n_clbits)
-
-    for q in init_ones:
-        qc.x(q)
-
-    for r in range(n_rounds):
-        c_start = nqubits + r * n_mid
-        qc.measure(measure_qubits, range(c_start, c_start + n_mid))
-
-        # Keep measurements mid-circuit.
-        for q in measure_qubits:
-            qc.rz(0.001, q)
-
-        qc.barrier()
-
-    qc.measure(range(nqubits), range(nqubits))
-
-    expected_mid = [
-        [1 if q in init_ones else 0 for q in measure_qubits]
-        for _ in range(n_rounds)
-    ]
-
-    expected_final = "".join("1" if q in init_ones else "0" for q in reversed(range(nqubits)))
-
-    return qc, expected_mid, expected_final
 
 
 @pytest.mark.parametrize(

--- a/tests/simulation/test_mid_circuit.py
+++ b/tests/simulation/test_mid_circuit.py
@@ -12,10 +12,11 @@ from src.quantum_gates.gates import standard_gates
 from src.quantum_gates.gates import almost_noise_free_gates
 from src.quantum_gates.utilities import DeviceParameters
 from src.quantum_gates.quantum_algorithms import hadamard_reverse_qft_circ
+from tests.helpers.paths import device_parameters_path
 
 
 _backend = FakeBrisbane()
-_location = "tests/helpers/device_parameters/ibm_kyoto/"
+_location = device_parameters_path("ibm_kyoto")
 _LAYOUT = [0, 1, 2, 3, 4]
 
 

--- a/tests/simulation/test_mid_circuit.py
+++ b/tests/simulation/test_mid_circuit.py
@@ -757,3 +757,217 @@ def test_array_mid_measure_entangled_correlated_parametrized(
     assert 0.30 < frac_zero < 0.70, (
         f"Expected roughly 50/50 collapse but got frac_zero={frac_zero:.2f}"
     )
+
+def _group_mid_events_by_round(mid_events, nqubits, n_mid, n_rounds):
+    """Group scalar mid-measure events back into array-measure rounds.
+
+    The simulator stores array-style qc.measure([...], [...]) as one scalar
+    event per measured qubit. We reconstruct the original array-measure rounds
+    using the classical-bit blocks assigned in the circuit.
+    """
+    grouped = []
+
+    for r in range(n_rounds):
+        c_start = nqubits + r * n_mid
+        c_end = c_start + n_mid
+
+        round_events = [
+            event for event in mid_events
+            if c_start <= event["clbits"][0] < c_end
+        ]
+
+        round_events = sorted(round_events, key=lambda e: e["clbits"][0])
+        grouped.append([int(event["outcome"][0]) for event in round_events])
+
+    return grouped
+
+
+def _deterministic_array_mid_measure_circuit(nqubits, init_ones, measure_qubits, n_rounds=1):
+    """Build deterministic circuits with array-style mid-circuit measurements.
+
+    Each round measures `measure_qubits` using one array-style qc.measure(...) call.
+    """
+    n_mid = len(measure_qubits)
+    n_clbits = nqubits + n_rounds * n_mid
+    qc = QuantumCircuit(nqubits, n_clbits)
+
+    for q in init_ones:
+        qc.x(q)
+
+    for r in range(n_rounds):
+        c_start = nqubits + r * n_mid
+        qc.measure(measure_qubits, range(c_start, c_start + n_mid))
+
+        # Keep measurements mid-circuit.
+        for q in measure_qubits:
+            qc.rz(0.001, q)
+
+        qc.barrier()
+
+    qc.measure(range(nqubits), range(nqubits))
+
+    expected_mid = [
+        [1 if q in init_ones else 0 for q in measure_qubits]
+        for _ in range(n_rounds)
+    ]
+
+    expected_final = "".join("1" if q in init_ones else "0" for q in range(nqubits))
+
+    return qc, expected_mid, expected_final
+
+
+@pytest.mark.parametrize(
+    "nqubits,init_ones,measure_qubits,n_rounds",
+    [
+        pytest.param(3, [0, 1], [0, 1], 1, id="3q_measure_2_once"),
+        pytest.param(5, [0, 2, 4], [0, 1, 2, 3, 4], 1, id="5q_measure_all_once"),
+        pytest.param(5, [1, 3], [0, 1, 2, 3, 4], 3, id="5q_measure_all_3_rounds"),
+        pytest.param(5, [0, 2, 4], [0, 2, 4], 5, id="5q_measure_subset_5_rounds"),
+    ],
+)
+def test_array_mid_measure_deterministic_parametrized(
+    nqubits,
+    init_ones,
+    measure_qubits,
+    n_rounds,
+):
+    """Array-style mid-circuit measurements should record the correct outcomes
+    for deterministic circuits and repeated measurement rounds."""
+    circ, expected_mid, expected_final = _deterministic_array_mid_measure_circuit(
+        nqubits=nqubits,
+        init_ones=init_ones,
+        measure_qubits=measure_qubits,
+        n_rounds=n_rounds,
+    )
+
+    t_circ = _transpile_midcircuit(circ, nqubits)
+
+    result = _run_sim(
+        t_circ,
+        nqubits,
+        almost_noise_free_gates,
+        BinaryCircuit,
+        shots=100,
+    )
+
+    n_mid = len(measure_qubits)
+
+    assert len(result["mid_counts"]) > 0
+    assert len(result["results"]) == 100
+
+    for shot in result["results"]:
+        assert len(shot["mid"]) == n_rounds * n_mid, (
+            f"Expected {n_rounds * n_mid} scalar mid-measure events, "
+            f"got {shot['mid']}"
+        )
+
+        grouped = _group_mid_events_by_round(
+            shot["mid"],
+            nqubits=nqubits,
+            n_mid=n_mid,
+            n_rounds=n_rounds,
+        )
+
+        assert grouped == expected_mid, (
+            f"Expected grouped mid outcomes {expected_mid}, got {grouped}"
+        )
+
+    probs = result["probs"]
+    assert probs.get(expected_final, 0.0) > 0.95, (
+        f"Expected final state |{expected_final}> but got probs={probs}"
+    )
+
+
+def _entangled_array_mid_measure_circuit(nqubits, entangle_qubits, n_rounds=1):
+    """Prepare a GHZ/Bell-like state on entangle_qubits and repeatedly
+    mid-measure them using array-style measurements."""
+    n_mid = len(entangle_qubits)
+    n_clbits = nqubits + n_rounds * n_mid
+    qc = QuantumCircuit(nqubits, n_clbits)
+
+    root = entangle_qubits[0]
+    qc.h(root)
+
+    for q in entangle_qubits[1:]:
+        qc.cx(root, q)
+
+    for r in range(n_rounds):
+        c_start = nqubits + r * n_mid
+        qc.measure(entangle_qubits, range(c_start, c_start + n_mid))
+
+        for q in entangle_qubits:
+            qc.rz(0.001, q)
+
+        qc.barrier()
+
+    qc.measure(range(nqubits), range(nqubits))
+
+    return qc
+
+
+@pytest.mark.parametrize(
+    "nqubits,entangle_qubits,n_rounds",
+    [
+        pytest.param(2, [0, 1], 1, id="bell_2q_once"),
+        pytest.param(3, [0, 1, 2], 1, id="ghz_3q_once"),
+        pytest.param(5, [0, 1, 2, 3, 4], 3, id="ghz_5q_3_rounds"),
+        pytest.param(5, [0, 2, 4], 4, id="subset_ghz_3q_4_rounds"),
+    ],
+)
+def test_array_mid_measure_entangled_correlated_parametrized(
+    nqubits,
+    entangle_qubits,
+    n_rounds,
+):
+    """Array-style mid-circuit measurements on Bell/GHZ states should remain
+    correlated across measured qubits and repeated rounds."""
+    circ = _entangled_array_mid_measure_circuit(
+        nqubits=nqubits,
+        entangle_qubits=entangle_qubits,
+        n_rounds=n_rounds,
+    )
+
+    t_circ = _transpile_midcircuit(circ, nqubits)
+
+    result = _run_sim(
+        t_circ,
+        nqubits,
+        almost_noise_free_gates,
+        BinaryCircuit,
+        shots=500,
+    )
+
+    n_mid = len(entangle_qubits)
+    first_round_values = []
+
+    for shot in result["results"]:
+        assert len(shot["mid"]) == n_rounds * n_mid, (
+            f"Expected {n_rounds * n_mid} scalar mid-measure events, "
+            f"got {shot['mid']}"
+        )
+
+        grouped = _group_mid_events_by_round(
+            shot["mid"],
+            nqubits=nqubits,
+            n_mid=n_mid,
+            n_rounds=n_rounds,
+        )
+
+        for observed in grouped:
+            assert len(observed) == n_mid
+            assert observed in ([0] * n_mid, [1] * n_mid), (
+                f"Expected correlated outcome, got {observed}"
+            )
+
+        for observed in grouped[1:]:
+            assert observed == grouped[0], (
+                f"Expected repeated measurements to match first collapse, got {grouped}"
+            )
+
+        first_round_values.append(grouped[0][0])
+
+    frac_zero = first_round_values.count(0) / len(first_round_values)
+
+    assert 0.30 < frac_zero < 0.70, (
+        f"Expected roughly 50/50 collapse but got frac_zero={frac_zero:.2f}"
+    )

--- a/tests/simulation/test_mid_circuit.py
+++ b/tests/simulation/test_mid_circuit.py
@@ -811,7 +811,7 @@ def _deterministic_array_mid_measure_circuit(nqubits, init_ones, measure_qubits,
         for _ in range(n_rounds)
     ]
 
-    expected_final = "".join("1" if q in init_ones else "0" for q in range(nqubits))
+    expected_final = "".join("1" if q in init_ones else "0" for q in reversed(range(nqubits)))
 
     return qc, expected_mid, expected_final
 

--- a/tests/simulation/test_reset_qubit.py
+++ b/tests/simulation/test_reset_qubit.py
@@ -8,9 +8,10 @@ from src.quantum_gates.simulators import MrAndersonSimulator
 from src.quantum_gates.circuits import EfficientCircuit, BinaryCircuit
 from src.quantum_gates.gates import standard_gates, almost_noise_free_gates
 from src.quantum_gates.utilities import DeviceParameters
+from tests.helpers.paths import device_parameters_path
 
 _backend = FakeBrisbane()
-_location = "tests/helpers/device_parameters/ibm_kyoto/"
+_location = device_parameters_path("ibm_kyoto")
 _LAYOUT = [0, 1, 2, 3, 4]
 
 def _device_param(nqubits):

--- a/tests/simulation/test_statevector_readout.py
+++ b/tests/simulation/test_statevector_readout.py
@@ -13,9 +13,10 @@ from src.quantum_gates.utilities import DeviceParameters
 from src.quantum_gates.utilities import (
     sv_normal_to_qiskit,
 ) 
+from tests.helpers.paths import device_parameters_path
 
 _backend = FakeBrisbane()
-_location = "tests/helpers/device_parameters/ibm_kyoto/"
+_location = device_parameters_path("ibm_kyoto")
 _LAYOUT = [0, 1, 2, 3, 4]
 
 ABS_TOL = 1e-6

--- a/tests/simulation/test_two_qubit_gate.py
+++ b/tests/simulation/test_two_qubit_gate.py
@@ -69,7 +69,7 @@ def test_non_consecutive_cnot_flips_target(circuit_class):
 
     # Compare dominant outcomes
     aer_dominant = max(aer_probs, key=aer_probs.get)
-    mr_dominant = max(result["probs"], key=result["probs"].get)
+    mr_dominant = max(result["mid_counts"], key=result["probs"].get)
     assert aer_dominant == mr_dominant, (
         f"MrAnderson dominant outcome '{mr_dominant}' does not match "
         f"AER '{aer_dominant}'"

--- a/tests/simulation/test_two_qubit_gate.py
+++ b/tests/simulation/test_two_qubit_gate.py
@@ -1,0 +1,295 @@
+import pytest
+import numpy as np
+
+from qiskit import QuantumCircuit, transpile
+from qiskit_ibm_runtime.fake_provider import FakeBrisbane
+
+from src.quantum_gates.simulators import MrAndersonSimulator
+from src.quantum_gates.circuits import EfficientCircuit, BinaryCircuit
+from src.quantum_gates.gates import standard_gates, almost_noise_free_gates
+from src.quantum_gates.utilities import DeviceParameters
+
+_backend = FakeBrisbane()
+_location = "tests/helpers/device_parameters/ibm_kyoto/"
+_LAYOUT = [0, 1, 2, 3, 4]
+
+
+def _device_param(nqubits):
+    dp = DeviceParameters(qubits_layout=_LAYOUT[:nqubits])
+    dp.load_from_texts(location=_location)
+    return dp.__dict__()
+
+
+def _transpile_circuit(circ, nqubits):
+    return transpile(
+        circ,
+        backend=_backend,
+        initial_layout=_LAYOUT[:nqubits],
+        seed_transpiler=42,
+        optimization_level=0,
+    )
+
+
+def _run_sim(t_circ, nqubits, gates, circuit_class, shots=200):
+    psi0 = np.zeros(2 ** nqubits, dtype=complex)
+    psi0[0] = 1
+    sim = MrAndersonSimulator(gates=gates, CircuitClass=circuit_class)
+    return sim.run(
+        t_qiskit_circ=t_circ,
+        psi0=psi0,
+        shots=shots,
+        device_param=_device_param(nqubits),
+        nqubit=nqubits,
+    )
+
+
+# ── Option 1: Correctness against known states ────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_cnot_flips_target(circuit_class):
+    """CNOT on non-consecutive qubits (0, 2): control |1>, target |0> -> target flips to |1>."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)          # set control qubit 0 to |1>
+    qc.cx(0, 2)      # CNOT on non-consecutive qubits 0 and 2
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
+
+    # Expected: qubit 0 = 1, qubit 1 = 0, qubit 2 = 1 -> "101"
+    p_101 = result["probs"].get("101", 0.0)
+    assert p_101 > 0.95, (
+        f"Expected P('101') > 0.95 after non-consecutive CNOT(0,2) "
+        f"but got {p_101:.4f} (probs={result['probs']})"
+    )
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_cnot_control_zero_no_flip(circuit_class):
+    """CNOT on non-consecutive qubits (0, 2): control |0> -> target should not flip."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.cx(0, 2)      # control is |0>, target should stay |0>
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
+
+    p_000 = result["probs"].get("000", 0.0)
+    assert p_000 > 0.95, (
+        f"Expected P('000') > 0.95 when control is |0> "
+        f"but got {p_000:.4f} (probs={result['probs']})"
+    )
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_cnot_middle_qubit_unaffected(circuit_class):
+    """CNOT on qubits (0, 2): middle qubit 1 should be unaffected."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)          # flip control
+    qc.cx(0, 2)      # non-consecutive CNOT
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
+
+    # Qubit 1 (middle bit of bitstring) should always be 0
+    for bitstr, p in result["probs"].items():
+        if p > 0.01:
+            assert bitstr[1] == "0", (
+                f"Middle qubit should be unaffected but found '{bitstr}' "
+                f"with p={p:.4f}"
+            )
+
+
+# ── Option 2: Equivalence with consecutive ────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_matches_consecutive_noiseless(circuit_class):
+    """Non-consecutive CNOT(0,2) should give same probabilities as
+    consecutive CNOT(0,1) on an equivalent circuit in the noiseless regime."""
+    nqubits = 3
+
+    # Non-consecutive: CNOT on qubits 0 and 2
+    qc_non_consec = QuantumCircuit(nqubits, nqubits)
+    qc_non_consec.h(0)
+    qc_non_consec.cx(0, 2)
+    qc_non_consec.measure(range(nqubits), range(nqubits))
+
+    # Consecutive equivalent: CNOT on qubits 0 and 1
+    qc_consec = QuantumCircuit(nqubits, nqubits)
+    qc_consec.h(0)
+    qc_consec.cx(0, 1)
+    qc_consec.measure(range(nqubits), range(nqubits))
+
+    t_non_consec = _transpile_circuit(qc_non_consec, nqubits)
+    t_consec = _transpile_circuit(qc_consec, nqubits)
+
+    result_nc = _run_sim(t_non_consec, nqubits, almost_noise_free_gates, circuit_class, shots=500)
+    result_c  = _run_sim(t_consec,     nqubits, almost_noise_free_gates, circuit_class, shots=500)
+
+    # Both should show ~50/50 split between two basis states
+    total_nc = sum(result_nc["probs"].values())
+    total_c  = sum(result_c["probs"].values())
+    assert np.isclose(total_nc, 1.0, atol=0.01), f"Non-consecutive probs don't sum to 1: {total_nc}"
+    assert np.isclose(total_c,  1.0, atol=0.01), f"Consecutive probs don't sum to 1: {total_c}"
+
+    # Both should have exactly 2 outcomes with roughly equal probability
+    nc_outcomes = {k: v for k, v in result_nc["probs"].items() if v > 0.05}
+    c_outcomes  = {k: v for k, v in result_c["probs"].items()  if v > 0.05}
+    assert len(nc_outcomes) == 2, f"Expected 2 outcomes but got {nc_outcomes}"
+    assert len(c_outcomes)  == 2, f"Expected 2 outcomes but got {c_outcomes}"
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_bell_state_correlations(circuit_class):
+    """H on qubit 0 + CNOT(0,2) should create entanglement between qubits 0 and 2,
+    with qubit 1 remaining in |0>."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 2)      # Bell state between qubits 0 and 2
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
+
+    # Only "000" and "101" should appear (qubits 0 and 2 correlated, qubit 1 = 0)
+    for bitstr, p in result["probs"].items():
+        if p > 0.05:
+            assert bitstr in ("000", "101"), (
+                f"Expected only '000' or '101' for Bell state on qubits 0,2 "
+                f"but found '{bitstr}' with p={p:.4f}"
+            )
+
+    p_000 = result["probs"].get("000", 0.0)
+    p_101 = result["probs"].get("101", 0.0)
+    assert 0.35 < p_000 < 0.65, f"Expected ~0.5 for '000' but got {p_000:.4f}"
+    assert 0.35 < p_101 < 0.65, f"Expected ~0.5 for '101' but got {p_101:.4f}"
+
+
+# ── Option 3: Noise consistency ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_noiseless_higher_fidelity_than_noisy(circuit_class):
+    """Noiseless non-consecutive CNOT should give higher fidelity than noisy."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)
+    qc.cx(0, 2)
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+
+    result_clean = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
+    result_noisy = _run_sim(t_circ, nqubits, standard_gates,           circuit_class, shots=300)
+
+    p_clean = result_clean["probs"].get("101", 0.0)
+    p_noisy = result_noisy["probs"].get("101", 0.0)
+
+    assert p_clean > p_noisy, (
+        f"Expected noiseless to have higher fidelity than noisy "
+        f"but got p_clean={p_clean:.4f} <= p_noisy={p_noisy:.4f}"
+    )
+    assert p_clean > 0.90, (
+        f"Expected P('101') > 0.90 for noiseless non-consecutive CNOT "
+        f"but got {p_clean:.4f}"
+    )
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_noise_params_preserved(circuit_class):
+    """Non-consecutive gate should use noise params of the actual qubits,
+    not the permuted positions — verified by checking noiseless gives near-ideal result."""
+    nqubits = 4
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.x(0)
+    qc.cx(0, 3)      # far apart qubits
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
+
+    p_1001 = result["probs"].get("1001", 0.0)
+    assert p_1001 > 0.90, (
+        f"Expected P('1001') > 0.90 for noiseless CNOT(0,3) "
+        f"but got {p_1001:.4f} (probs={result['probs']})"
+    )
+
+
+# ── Option 4: End-to-end integration ─────────────────────────────────────────
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_gate_completes_without_error(circuit_class):
+    """Non-consecutive two-qubit gate should run through the full pipeline
+    without raising any exception."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.cx(0, 2)
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=100)
+
+    assert "probs" in result
+    assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_gate_mixed_with_consecutive(circuit_class):
+    """Circuit with both consecutive and non-consecutive gates should run correctly."""
+    nqubits = 4
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 1)      # consecutive
+    qc.cx(1, 3)      # non-consecutive
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
+
+    assert "probs" in result
+    assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
+    assert len(result["probs"]) > 0
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_gate_with_mid_measurement(circuit_class):
+    """Non-consecutive gate followed by a mid-circuit measurement should work end-to-end."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits + 1)
+    qc.x(0)
+    qc.cx(0, 2)               # non-consecutive
+    qc.measure(2, nqubits)    # mid-circuit measure qubit 2
+    qc.barrier()
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+    result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
+
+    assert "probs" in result
+    assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
+
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+def test_non_consecutive_gate_result_is_reproducible(circuit_class):
+    """Two runs with the same seed should give similar probability distributions."""
+    nqubits = 3
+    qc = QuantumCircuit(nqubits, nqubits)
+    qc.h(0)
+    qc.cx(0, 2)
+    qc.measure(range(nqubits), range(nqubits))
+
+    t_circ = _transpile_circuit(qc, nqubits)
+
+    result1 = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
+    result2 = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
+
+    # Both runs should show the same dominant outcomes
+    dominant1 = {k for k, v in result1["probs"].items() if v > 0.1}
+    dominant2 = {k for k, v in result2["probs"].items() if v > 0.1}
+    assert dominant1 == dominant2, (
+        f"Dominant outcomes differ between runs: {dominant1} vs {dominant2}"
+    )

--- a/tests/simulation/test_two_qubit_gate.py
+++ b/tests/simulation/test_two_qubit_gate.py
@@ -75,7 +75,7 @@ def test_non_consecutive_cnot_flips_target(circuit_class):
         f"AER '{aer_dominant}'"
     )
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_cnot_control_zero_no_flip(circuit_class):
     """CNOT on non-consecutive qubits (4, 15): control |0> -> target should not flip."""
     nqubits = 16
@@ -86,13 +86,13 @@ def test_non_consecutive_cnot_control_zero_no_flip(circuit_class):
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
 
     zero_state = "0" * nqubits
-    p_zero = result["probs"].get(zero_state, 0.0)
+    p_zero = result["mid_counts"].get(zero_state, 0.0)
     assert p_zero > 0.95, (
         f"Expected P(|0...0>) > 0.95 when control is |0> "
         f"but got {p_zero:.4f} (probs={result['probs']})"
     )
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_cnot_middle_qubits_unaffected(circuit_class):
     """CNOT on qubits (4, 15): qubits 5-14 should be unaffected."""
     nqubits = 16
@@ -103,7 +103,7 @@ def test_non_consecutive_cnot_middle_qubits_unaffected(circuit_class):
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
 
-    for bitstr, p in result["probs"].items():
+    for bitstr, p in result["mid_counts"].items():
         if p > 0.01:
             # qubits 5-14 should all be 0
             for q in range(5, 15):
@@ -114,7 +114,7 @@ def test_non_consecutive_cnot_middle_qubits_unaffected(circuit_class):
 
 # ── Option 2: Equivalence with consecutive ────────────────────────────────────
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_matches_consecutive_noiseless(circuit_class):
     """H on qubit 4 + CNOT(4,15) and H on qubit 4 + CNOT(4,5) should both
     produce a 50/50 split between exactly two basis states."""
@@ -136,15 +136,21 @@ def test_non_consecutive_matches_consecutive_noiseless(circuit_class):
     result_nc = _run_sim(t_non_consec, nqubits, almost_noise_free_gates, circuit_class, shots=500)
     result_c  = _run_sim(t_consec,     nqubits, almost_noise_free_gates, circuit_class, shots=500)
 
-    assert np.isclose(sum(result_nc["probs"].values()), 1.0, atol=0.01)
-    assert np.isclose(sum(result_c["probs"].values()),  1.0, atol=0.01)
+    total = sum(result_nc["mid_counts"].values())
+    result_nc["mid_counts"] = {k: v / total for k, v in result_nc["mid_counts"].items()}
 
-    nc_outcomes = {k: v for k, v in result_nc["probs"].items() if v > 0.05}
-    c_outcomes  = {k: v for k, v in result_c["probs"].items()  if v > 0.05}
+    total = sum(result_c["mid_counts"].values())
+    result_c["mid_counts"] = {k: v / total for k, v in result_c["mid_counts"].items()}
+
+    assert np.isclose(sum(result_nc["mid_counts"].values()), 1.0, atol=0.01)
+    assert np.isclose(sum(result_c["mid_counts"].values()),  1.0, atol=0.01)
+
+    nc_outcomes = {k: v for k, v in result_nc["mid_counts"].items() if v > 0.05}
+    c_outcomes  = {k: v for k, v in result_c["mid_counts"].items()  if v > 0.05}
     assert len(nc_outcomes) == 2, f"Expected 2 outcomes but got {nc_outcomes}"
     assert len(c_outcomes)  == 2, f"Expected 2 outcomes but got {c_outcomes}"
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_bell_state_correlations(circuit_class):
     """H on qubit 4 + CNOT(4,15) should entangle qubits 4 and 15,
     with all other qubits remaining in |0>."""
@@ -156,7 +162,7 @@ def test_non_consecutive_bell_state_correlations(circuit_class):
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
 
-    for bitstr, p in result["probs"].items():
+    for bitstr, p in result["mid_counts"].items():
         if p > 0.05:
             q4  = bitstr[-(4+1)]
             q15 = bitstr[-(15+1)]
@@ -173,7 +179,7 @@ def test_non_consecutive_bell_state_correlations(circuit_class):
 
 # ── Option 3: Noise consistency ───────────────────────────────────────────────
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_noiseless_higher_fidelity_than_noisy(circuit_class):
     """Noiseless non-consecutive CNOT(4,15) should give higher fidelity than noisy."""
     nqubits = 16
@@ -192,8 +198,8 @@ def test_non_consecutive_noiseless_higher_fidelity_than_noisy(circuit_class):
     target[-(15+1)] = "1"
     target_str = "".join(target)
 
-    p_clean = result_clean["probs"].get(target_str, 0.0)
-    p_noisy = result_noisy["probs"].get(target_str, 0.0)
+    p_clean = result_clean["mid_counts"].get(target_str, 0.0)
+    p_noisy = result_noisy["mid_counts"].get(target_str, 0.0)
 
     assert p_clean > p_noisy, (
         f"Expected noiseless to have higher fidelity than noisy "
@@ -204,7 +210,7 @@ def test_non_consecutive_noiseless_higher_fidelity_than_noisy(circuit_class):
         f"but got {p_clean:.4f}"
     )
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_noise_params_preserved(circuit_class):
     """Non-consecutive gate should use noise params of the actual qubits —
     verified by checking noiseless gives near-ideal result."""
@@ -221,15 +227,15 @@ def test_non_consecutive_noise_params_preserved(circuit_class):
     target[-(15+1)] = "1"
     target_str = "".join(target)
 
-    p = result["probs"].get(target_str, 0.0)
+    p = result["mid_counts"].get(target_str, 0.0)
     assert p > 0.90, (
         f"Expected P(target) > 0.90 for noiseless CNOT(4,15) "
-        f"but got {p:.4f} (probs={result['probs']})"
+        f"but got {p:.4f} (probs={result['mid_counts']})"
     )
 
 # ── Option 4: End-to-end integration ─────────────────────────────────────────
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_gate_completes_without_error(circuit_class):
     """Non-consecutive two-qubit gate should run through the full pipeline
     without raising any exception."""
@@ -240,10 +246,13 @@ def test_non_consecutive_gate_completes_without_error(circuit_class):
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=100)
 
-    assert "probs" in result
-    assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
+    total = sum(result["mid_counts"].values())
+    result["mid_counts"] = {k: v / total for k, v in result["mid_counts"].items()}
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+    assert "mid_counts" in result
+    assert np.isclose(sum(result["mid_counts"].values()), 1.0, atol=0.01)
+
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_gate_mixed_with_consecutive(circuit_class):
     """Circuit with both consecutive and non-consecutive gates should run correctly."""
     nqubits = 16
@@ -254,12 +263,16 @@ def test_non_consecutive_gate_mixed_with_consecutive(circuit_class):
     qc.measure(range(nqubits), range(nqubits))
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
+    
+    total = sum(result["mid_counts"].values())
+    result["mid_counts"] = {k: v / total for k, v in result["mid_counts"].items()}
 
-    assert "probs" in result
-    assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
-    assert len(result["probs"]) > 0
+    
+    assert "mid_counts" in result
+    assert np.isclose(sum(result["mid_counts"].values()), 1.0, atol=0.01)
+    assert len(result["mid_counts"]) > 0
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_gate_with_mid_measurement(circuit_class):
     """Non-consecutive gate followed by a mid-circuit measurement should work end-to-end."""
     nqubits = 16
@@ -271,11 +284,14 @@ def test_non_consecutive_gate_with_mid_measurement(circuit_class):
     qc.measure(range(nqubits), range(nqubits))
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
+    
+    total = sum(result["mid_counts"].values())
+    result["mid_counts"] = {k: v / total for k, v in result["mid_counts"].items()}
 
-    assert "probs" in result
-    assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
+    assert "mid_counts" in result
+    assert np.isclose(sum(result["mid_counts"].values()), 1.0, atol=0.01)
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_gate_result_is_reproducible(circuit_class):
     """Two runs should give similar probability distributions."""
     nqubits = 16
@@ -288,8 +304,8 @@ def test_non_consecutive_gate_result_is_reproducible(circuit_class):
     result1 = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
     result2 = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
 
-    dominant1 = {k for k, v in result1["probs"].items() if v > 0.1}
-    dominant2 = {k for k, v in result2["probs"].items() if v > 0.1}
+    dominant1 = {k for k, v in result1["mid_counts"].items() if v > 0.1}
+    dominant2 = {k for k, v in result2["mid_counts"].items() if v > 0.1}
     assert dominant1 == dominant2, (
         f"Dominant outcomes differ between runs: {dominant1} vs {dominant2}"
     )

--- a/tests/simulation/test_two_qubit_gate.py
+++ b/tests/simulation/test_two_qubit_gate.py
@@ -1,23 +1,30 @@
 import pytest
 import numpy as np
-
 from qiskit import QuantumCircuit, transpile
 from qiskit_ibm_runtime.fake_provider import FakeBrisbane
-
 from src.quantum_gates.simulators import MrAndersonSimulator
 from src.quantum_gates.circuits import EfficientCircuit, BinaryCircuit
 from src.quantum_gates.gates import standard_gates, almost_noise_free_gates
 from src.quantum_gates.utilities import DeviceParameters
+from qiskit_aer import AerSimulator
+
 
 _backend = FakeBrisbane()
-_location = "tests/helpers/device_parameters/ibm_kyoto/"
-_LAYOUT = [0, 1, 2, 3, 4]
-
+_LAYOUT = list(range(16))
 
 def _device_param(nqubits):
     dp = DeviceParameters(qubits_layout=_LAYOUT[:nqubits])
-    dp.load_from_texts(location=_location)
+    dp.load_from_backend(_backend)
     return dp.__dict__()
+
+
+def _aer_reference(qc, nqubits, shots=1000):
+    sim = AerSimulator()
+    t_circ = transpile(qc, sim)
+    result = sim.run(t_circ, shots=shots).result()
+    counts = result.get_counts()
+    total = sum(counts.values())
+    return {k: v/total for k, v in counts.items()}
 
 
 def _transpile_circuit(circ, nqubits):
@@ -28,7 +35,6 @@ def _transpile_circuit(circ, nqubits):
         seed_transpiler=42,
         optimization_level=0,
     )
-
 
 def _run_sim(t_circ, nqubits, gates, circuit_class, shots=200):
     psi0 = np.zeros(2 ** nqubits, dtype=complex)
@@ -42,86 +48,86 @@ def _run_sim(t_circ, nqubits, gates, circuit_class, shots=200):
         nqubit=nqubits,
     )
 
-
 # ── Option 1: Correctness against known states ────────────────────────────────
 
-@pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
+@pytest.mark.parametrize("circuit_class", [EfficientCircuit])
 def test_non_consecutive_cnot_flips_target(circuit_class):
-    """CNOT on non-consecutive qubits (0, 2): control |1>, target |0> -> target flips to |1>."""
-    nqubits = 3
+    """CNOT on non-consecutive qubits (4, 15): control |1>, target |0> -> target flips to |1>."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.x(0)          # set control qubit 0 to |1>
-    qc.cx(0, 2)      # CNOT on non-consecutive qubits 0 and 2
+    qc.x(4)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
+
+    # Check what AER says first
+    aer_probs = _aer_reference(qc, nqubits)
+    print(f"AER dominant outcome: {max(aer_probs, key=aer_probs.get)}")
+
 
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
 
-    # Expected: qubit 0 = 1, qubit 1 = 0, qubit 2 = 1 -> "101"
-    p_101 = result["probs"].get("101", 0.0)
-    assert p_101 > 0.95, (
-        f"Expected P('101') > 0.95 after non-consecutive CNOT(0,2) "
-        f"but got {p_101:.4f} (probs={result['probs']})"
+    # Compare dominant outcomes
+    aer_dominant = max(aer_probs, key=aer_probs.get)
+    mr_dominant = max(result["probs"], key=result["probs"].get)
+    assert aer_dominant == mr_dominant, (
+        f"MrAnderson dominant outcome '{mr_dominant}' does not match "
+        f"AER '{aer_dominant}'"
     )
-
 
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_cnot_control_zero_no_flip(circuit_class):
-    """CNOT on non-consecutive qubits (0, 2): control |0> -> target should not flip."""
-    nqubits = 3
+    """CNOT on non-consecutive qubits (4, 15): control |0> -> target should not flip."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.cx(0, 2)      # control is |0>, target should stay |0>
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
 
-    p_000 = result["probs"].get("000", 0.0)
-    assert p_000 > 0.95, (
-        f"Expected P('000') > 0.95 when control is |0> "
-        f"but got {p_000:.4f} (probs={result['probs']})"
+    zero_state = "0" * nqubits
+    p_zero = result["probs"].get(zero_state, 0.0)
+    assert p_zero > 0.95, (
+        f"Expected P(|0...0>) > 0.95 when control is |0> "
+        f"but got {p_zero:.4f} (probs={result['probs']})"
     )
 
-
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
-def test_non_consecutive_cnot_middle_qubit_unaffected(circuit_class):
-    """CNOT on qubits (0, 2): middle qubit 1 should be unaffected."""
-    nqubits = 3
+def test_non_consecutive_cnot_middle_qubits_unaffected(circuit_class):
+    """CNOT on qubits (4, 15): qubits 5-14 should be unaffected."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.x(0)          # flip control
-    qc.cx(0, 2)      # non-consecutive CNOT
+    qc.x(4)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
 
-    # Qubit 1 (middle bit of bitstring) should always be 0
     for bitstr, p in result["probs"].items():
         if p > 0.01:
-            assert bitstr[1] == "0", (
-                f"Middle qubit should be unaffected but found '{bitstr}' "
-                f"with p={p:.4f}"
-            )
-
+            # qubits 5-14 should all be 0
+            for q in range(5, 15):
+                assert bitstr[-(q+1)] == "0", (
+                    f"Qubit {q} should be unaffected but found '{bitstr}' "
+                    f"with p={p:.4f}"
+                )
 
 # ── Option 2: Equivalence with consecutive ────────────────────────────────────
 
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_matches_consecutive_noiseless(circuit_class):
-    """Non-consecutive CNOT(0,2) should give same probabilities as
-    consecutive CNOT(0,1) on an equivalent circuit in the noiseless regime."""
-    nqubits = 3
+    """H on qubit 4 + CNOT(4,15) and H on qubit 4 + CNOT(4,5) should both
+    produce a 50/50 split between exactly two basis states."""
+    nqubits = 16
 
-    # Non-consecutive: CNOT on qubits 0 and 2
     qc_non_consec = QuantumCircuit(nqubits, nqubits)
-    qc_non_consec.h(0)
-    qc_non_consec.cx(0, 2)
+    qc_non_consec.h(4)
+    qc_non_consec.cx(4, 15)
     qc_non_consec.measure(range(nqubits), range(nqubits))
 
-    # Consecutive equivalent: CNOT on qubits 0 and 1
     qc_consec = QuantumCircuit(nqubits, nqubits)
-    qc_consec.h(0)
-    qc_consec.cx(0, 1)
+    qc_consec.h(4)
+    qc_consec.cx(4, 5)
     qc_consec.measure(range(nqubits), range(nqubits))
 
     t_non_consec = _transpile_circuit(qc_non_consec, nqubits)
@@ -130,94 +136,96 @@ def test_non_consecutive_matches_consecutive_noiseless(circuit_class):
     result_nc = _run_sim(t_non_consec, nqubits, almost_noise_free_gates, circuit_class, shots=500)
     result_c  = _run_sim(t_consec,     nqubits, almost_noise_free_gates, circuit_class, shots=500)
 
-    # Both should show ~50/50 split between two basis states
-    total_nc = sum(result_nc["probs"].values())
-    total_c  = sum(result_c["probs"].values())
-    assert np.isclose(total_nc, 1.0, atol=0.01), f"Non-consecutive probs don't sum to 1: {total_nc}"
-    assert np.isclose(total_c,  1.0, atol=0.01), f"Consecutive probs don't sum to 1: {total_c}"
+    assert np.isclose(sum(result_nc["probs"].values()), 1.0, atol=0.01)
+    assert np.isclose(sum(result_c["probs"].values()),  1.0, atol=0.01)
 
-    # Both should have exactly 2 outcomes with roughly equal probability
     nc_outcomes = {k: v for k, v in result_nc["probs"].items() if v > 0.05}
     c_outcomes  = {k: v for k, v in result_c["probs"].items()  if v > 0.05}
     assert len(nc_outcomes) == 2, f"Expected 2 outcomes but got {nc_outcomes}"
     assert len(c_outcomes)  == 2, f"Expected 2 outcomes but got {c_outcomes}"
 
-
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_bell_state_correlations(circuit_class):
-    """H on qubit 0 + CNOT(0,2) should create entanglement between qubits 0 and 2,
-    with qubit 1 remaining in |0>."""
-    nqubits = 3
+    """H on qubit 4 + CNOT(4,15) should entangle qubits 4 and 15,
+    with all other qubits remaining in |0>."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.h(0)
-    qc.cx(0, 2)      # Bell state between qubits 0 and 2
+    qc.h(4)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
 
-    # Only "000" and "101" should appear (qubits 0 and 2 correlated, qubit 1 = 0)
     for bitstr, p in result["probs"].items():
         if p > 0.05:
-            assert bitstr in ("000", "101"), (
-                f"Expected only '000' or '101' for Bell state on qubits 0,2 "
+            q4  = bitstr[-(4+1)]
+            q15 = bitstr[-(15+1)]
+            assert q4 == q15, (
+                f"Expected qubits 4 and 15 to be correlated "
                 f"but found '{bitstr}' with p={p:.4f}"
             )
-
-    p_000 = result["probs"].get("000", 0.0)
-    p_101 = result["probs"].get("101", 0.0)
-    assert 0.35 < p_000 < 0.65, f"Expected ~0.5 for '000' but got {p_000:.4f}"
-    assert 0.35 < p_101 < 0.65, f"Expected ~0.5 for '101' but got {p_101:.4f}"
-
+            # all other qubits should be 0
+            for q in range(nqubits):
+                if q not in (4, 15):
+                    assert bitstr[-(q+1)] == "0", (
+                        f"Qubit {q} should be 0 but found '{bitstr}' with p={p:.4f}"
+                    )
 
 # ── Option 3: Noise consistency ───────────────────────────────────────────────
 
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_noiseless_higher_fidelity_than_noisy(circuit_class):
-    """Noiseless non-consecutive CNOT should give higher fidelity than noisy."""
-    nqubits = 3
+    """Noiseless non-consecutive CNOT(4,15) should give higher fidelity than noisy."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.x(0)
-    qc.cx(0, 2)
+    qc.x(4)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
 
     result_clean = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
     result_noisy = _run_sim(t_circ, nqubits, standard_gates,           circuit_class, shots=300)
 
-    p_clean = result_clean["probs"].get("101", 0.0)
-    p_noisy = result_noisy["probs"].get("101", 0.0)
+    # In the target state qubits 4 and 15 are 1, all others 0
+    target = ["0"] * nqubits
+    target[-(4+1)]  = "1"
+    target[-(15+1)] = "1"
+    target_str = "".join(target)
+
+    p_clean = result_clean["probs"].get(target_str, 0.0)
+    p_noisy = result_noisy["probs"].get(target_str, 0.0)
 
     assert p_clean > p_noisy, (
         f"Expected noiseless to have higher fidelity than noisy "
         f"but got p_clean={p_clean:.4f} <= p_noisy={p_noisy:.4f}"
     )
     assert p_clean > 0.90, (
-        f"Expected P('101') > 0.90 for noiseless non-consecutive CNOT "
+        f"Expected P(target) > 0.90 for noiseless CNOT(4,15) "
         f"but got {p_clean:.4f}"
     )
 
-
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_noise_params_preserved(circuit_class):
-    """Non-consecutive gate should use noise params of the actual qubits,
-    not the permuted positions — verified by checking noiseless gives near-ideal result."""
-    nqubits = 4
+    """Non-consecutive gate should use noise params of the actual qubits —
+    verified by checking noiseless gives near-ideal result."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.x(0)
-    qc.cx(0, 3)      # far apart qubits
+    qc.x(4)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
 
-    p_1001 = result["probs"].get("1001", 0.0)
-    assert p_1001 > 0.90, (
-        f"Expected P('1001') > 0.90 for noiseless CNOT(0,3) "
-        f"but got {p_1001:.4f} (probs={result['probs']})"
-    )
+    target = ["0"] * nqubits
+    target[-(4+1)]  = "1"
+    target[-(15+1)] = "1"
+    target_str = "".join(target)
 
+    p = result["probs"].get(target_str, 0.0)
+    assert p > 0.90, (
+        f"Expected P(target) > 0.90 for noiseless CNOT(4,15) "
+        f"but got {p:.4f} (probs={result['probs']})"
+    )
 
 # ── Option 4: End-to-end integration ─────────────────────────────────────────
 
@@ -225,28 +233,25 @@ def test_non_consecutive_noise_params_preserved(circuit_class):
 def test_non_consecutive_gate_completes_without_error(circuit_class):
     """Non-consecutive two-qubit gate should run through the full pipeline
     without raising any exception."""
-    nqubits = 3
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.cx(0, 2)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=100)
 
     assert "probs" in result
     assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
 
-
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_gate_mixed_with_consecutive(circuit_class):
     """Circuit with both consecutive and non-consecutive gates should run correctly."""
-    nqubits = 4
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.h(0)
-    qc.cx(0, 1)      # consecutive
-    qc.cx(1, 3)      # non-consecutive
+    qc.h(4)
+    qc.cx(4, 5)      # consecutive
+    qc.cx(4, 15)     # non-consecutive
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=300)
 
@@ -254,40 +259,35 @@ def test_non_consecutive_gate_mixed_with_consecutive(circuit_class):
     assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
     assert len(result["probs"]) > 0
 
-
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_gate_with_mid_measurement(circuit_class):
     """Non-consecutive gate followed by a mid-circuit measurement should work end-to-end."""
-    nqubits = 3
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits + 1)
-    qc.x(0)
-    qc.cx(0, 2)               # non-consecutive
-    qc.measure(2, nqubits)    # mid-circuit measure qubit 2
+    qc.x(4)
+    qc.cx(4, 15)
+    qc.measure(15, nqubits)    # mid-circuit measure qubit 15
     qc.barrier()
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
     result = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=200)
 
     assert "probs" in result
     assert np.isclose(sum(result["probs"].values()), 1.0, atol=0.01)
 
-
 @pytest.mark.parametrize("circuit_class", [EfficientCircuit, BinaryCircuit])
 def test_non_consecutive_gate_result_is_reproducible(circuit_class):
-    """Two runs with the same seed should give similar probability distributions."""
-    nqubits = 3
+    """Two runs should give similar probability distributions."""
+    nqubits = 16
     qc = QuantumCircuit(nqubits, nqubits)
-    qc.h(0)
-    qc.cx(0, 2)
+    qc.h(4)
+    qc.cx(4, 15)
     qc.measure(range(nqubits), range(nqubits))
-
     t_circ = _transpile_circuit(qc, nqubits)
 
     result1 = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
     result2 = _run_sim(t_circ, nqubits, almost_noise_free_gates, circuit_class, shots=500)
 
-    # Both runs should show the same dominant outcomes
     dominant1 = {k for k, v in result1["probs"].items() if v > 0.1}
     dominant2 = {k for k, v in result2["probs"].items() if v > 0.1}
     assert dominant1 == dominant2, (

--- a/tests/utility/test_device_parameters.py
+++ b/tests/utility/test_device_parameters.py
@@ -2,9 +2,10 @@ import pytest
 import numpy as np
 
 from src.quantum_gates.utilities import DeviceParameters
+from tests.helpers.paths import device_parameters_path
 
 
-location = 'tests/helpers/device_parameters/ibm_kyiv/'
+location = device_parameters_path("ibm_kyiv")
 invalid_location = 'invalid_location'
 qubits_layout = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 

--- a/tests/utility/test_opt_algo.py
+++ b/tests/utility/test_opt_algo.py
@@ -12,9 +12,10 @@ from src.quantum_gates.circuits import BinaryCircuit
 from src.quantum_gates.gates import standard_gates
 from src.quantum_gates.backends import BinaryBackend
 from src.quantum_gates._simulation.simulator import _apply_gates_on_circuit
+from tests.helpers.paths import device_parameters_path
 
 
-location = "tests/helpers/device_parameters/ibm_kyoto/"
+location = device_parameters_path("ibm_kyoto")
 
 backend = setup_backend(device_name=FakeBrisbane(), use_fake=True)
 

--- a/tests/utility/test_simulation_utility.py
+++ b/tests/utility/test_simulation_utility.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from src.quantum_gates.utilities import post_process_split
-from src.quantum_gates._utility.simulations_utility import apply_phase_to_qubit, apply_phase_corrections, compute_born_probability, collapse_statevector
+from src.quantum_gates._utility.simulations_utility import apply_phase_to_qubit, apply_phase_corrections, compute_born_probability, collapse_statevector, permute_to_adjacent, permute_back
 
 
 location = 'tests/helpers/result_samples'
@@ -217,6 +217,7 @@ def test_born_prob_zero_state():
     psi = np.array([1.0, 0.0], dtype=complex)
     assert np.isclose(compute_born_probability(psi, target_qubit=0, n=1), 1.0)
 
+
 def test_born_prob_one_state():
     # |1> state: probability of measuring 0 should be 0.0
     psi = np.array([0.0, 1.0], dtype=complex)
@@ -228,6 +229,7 @@ def test_born_probability_superposition():
     psi = np.array([1, 1], dtype=complex) / np.sqrt(2)
     assert np.isclose(compute_born_probability(psi, 0, 1), 0.5)
 
+
 def test_born_prob_sums_to_one():
     # p0 + p1 should always equal 1 for a normalised statevector
     rng = np.random.default_rng(0)
@@ -235,6 +237,7 @@ def test_born_prob_sums_to_one():
     psi /= np.linalg.norm(psi)
     p0 = compute_born_probability(psi, target_qubit=1, n=3)
     assert np.isclose(p0 + (1.0 - p0), 1.0)
+
 
 def test_old_vs_new_born_probability():
     # compare old loop implementation against new vectorised one
@@ -253,6 +256,7 @@ def test_old_vs_new_born_probability():
     p0_new = compute_born_probability(psi, target, n)
     assert np.isclose(p0_old, p0_new)
 
+
 def test_collapse_zeros_out_correct_amplitudes():
     # |+> collapsed to 0: |1> amplitude should be zeroed
     psi = np.array([1.0, 1.0], dtype=complex) / np.sqrt(2)
@@ -260,12 +264,14 @@ def test_collapse_zeros_out_correct_amplitudes():
     assert result[1] == 0.0
     assert result[0] != 0.0
 
+
 def test_collapse_to_one_zeros_correct_amplitudes():
     # |+> collapsed to 1: |0> amplitude should be zeroed
     psi = np.array([1.0, 1.0], dtype=complex) / np.sqrt(2)
     result = collapse_statevector(psi.copy(), target_qubit=0, outcome=1, n=1)
     assert result[0] == 0.0
     assert result[1] != 0.0
+
 
 def test_collapse_matches_old_loop():
     # regression test: new vectorised collapse matches old Python loop
@@ -283,6 +289,7 @@ def test_collapse_matches_old_loop():
     psi_new = collapse_statevector(psi.copy(), target, outcome, n)
     np.testing.assert_array_almost_equal(psi_new, psi_old)
 
+
 def test_collapse_preserves_correct_amplitudes():
     # amplitudes consistent with outcome should be untouched
     rng = np.random.default_rng(3)
@@ -295,3 +302,134 @@ def test_collapse_preserves_correct_amplitudes():
     for idx in range(len(result)):
         if ((idx >> (n - 1 - target)) & 1) == 0:
             assert result[idx] == psi_original[idx]
+
+
+def computational_basis_state(index: int, n: int) -> np.ndarray:
+    psi = np.zeros(2**n, dtype=complex)
+    psi[index] = 1.0
+    return psi
+
+
+def test_permute_brings_qubits_to_front():
+    # After permutation, q_ctr_v and q_trg_v should be at positions 0 and 1
+    n = 4
+    rng = np.random.default_rng(42)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=0, q_trg_v=3, n=n)
+
+    assert perm[0] == 0
+    assert perm[1] == 3
+
+
+def test_permute_consecutive_qubits_unchanged():
+    # If qubits are already at 0 and 1, permutation should be identity
+    n = 4
+    rng = np.random.default_rng(0)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=0, q_trg_v=1, n=n)
+    np.testing.assert_array_almost_equal(psi_permuted, psi)
+
+
+def test_permute_preserves_norm():
+    n = 5
+    rng = np.random.default_rng(7)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=1, q_trg_v=4, n=n)
+    assert np.isclose(np.linalg.norm(psi_permuted), 1.0)
+
+
+def test_permute_preserves_all_amplitudes():
+    # Permutation should not change the set of amplitudes, just reorder them
+    n = 4
+    rng = np.random.default_rng(3)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=0, q_trg_v=3, n=n)
+
+    np.testing.assert_array_almost_equal(
+        np.sort(np.abs(psi_permuted)),
+        np.sort(np.abs(psi))
+    )
+
+
+def test_permute_perm_is_valid_permutation():
+    # perm should be a valid permutation of range(n)
+    n = 5
+    rng = np.random.default_rng(1)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    _, perm = permute_to_adjacent(psi, q_ctr_v=2, q_trg_v=4, n=n)
+    assert sorted(perm) == list(range(n))
+
+
+def test_permute_back_inverts_permute_to_adjacent():
+    # Round trip should recover original psi exactly
+    n = 4
+    rng = np.random.default_rng(42)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=0, q_trg_v=3, n=n)
+    psi_recovered = permute_back(psi_permuted, perm, n)
+
+    np.testing.assert_array_almost_equal(psi_recovered, psi)
+
+
+def test_permute_back_inverts_for_various_qubit_pairs():
+    n = 5
+    pairs = [(0, 2), (1, 4), (0, 4), (2, 3), (1, 3)]
+    rng = np.random.default_rng(99)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    for q_ctr_v, q_trg_v in pairs:
+        psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v, q_trg_v, n)
+        psi_recovered = permute_back(psi_permuted, perm, n)
+        np.testing.assert_array_almost_equal(psi_recovered, psi,
+            err_msg=f"Round trip failed for qubits ({q_ctr_v}, {q_trg_v})")
+
+
+def test_permute_back_preserves_norm():
+    n = 4
+    rng = np.random.default_rng(5)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=1, q_trg_v=3, n=n)
+    psi_recovered = permute_back(psi_permuted, perm, n)
+
+    assert np.isclose(np.linalg.norm(psi_recovered), 1.0)
+
+
+def test_permute_back_consecutive_qubits_unchanged():
+    # If already consecutive, round trip should be identity
+    n = 4
+    rng = np.random.default_rng(11)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=0, q_trg_v=1, n=n)
+    psi_recovered = permute_back(psi_permuted, perm, n)
+
+    np.testing.assert_array_almost_equal(psi_recovered, psi)
+
+
+def test_permute_back_large_statevector():
+    # Sanity check at 2^17
+    n = 17
+    rng = np.random.default_rng(0)
+    psi = rng.random(2**n) + 1j * rng.random(2**n)
+    psi /= np.linalg.norm(psi)
+
+    psi_permuted, perm = permute_to_adjacent(psi, q_ctr_v=0, q_trg_v=16, n=n)
+    psi_recovered = permute_back(psi_permuted, perm, n)
+
+    np.testing.assert_array_almost_equal(psi_recovered, psi)

--- a/tests/utility/test_simulation_utility.py
+++ b/tests/utility/test_simulation_utility.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from src.quantum_gates.utilities import post_process_split
-from src.quantum_gates._utility.simulations_utility import apply_phase_to_qubit, apply_phase_corrections, compute_born_probability, collapse_statevector
+from src.quantum_gates._utility.simulations_utility import apply_phase_to_qubit, apply_phase_corrections, compute_born_probability, collapse_statevector, permute_to_adjacent, permute_back
 from tests.helpers.paths import helper_path
 
 

--- a/tests/utility/test_simulation_utility.py
+++ b/tests/utility/test_simulation_utility.py
@@ -4,9 +4,10 @@ import pytest
 
 from src.quantum_gates.utilities import post_process_split
 from src.quantum_gates._utility.simulations_utility import apply_phase_to_qubit, apply_phase_corrections, compute_born_probability, collapse_statevector
+from tests.helpers.paths import helper_path
 
 
-location = 'tests/helpers/result_samples'
+location = helper_path("result_samples")
 
 
 def test_apply_phase_to_qubit_raises_on_real_array():


### PR DESCRIPTION

## Non-consecutive two-qubit gates via statevector permutation

This PR adds support for applying two-qubit gates (ECR, CNOT) on non-consecutive qubits in the MrAnderson simulator. Previously, the circuit builder enforced a hard constraint that two-qubit gates could
only act on neighbouring qubits (`assert abs(i - k) == 1`), making it impossible to simulate circuits where gates act on physically non-adjacent qubits without manually inserting SWAP chains.


Rather than refactoring the entire optimizer and backend, this PR takes a targeted approach: detect non-consecutive gates early in the pipeline, handle them via statevector axis permutation, and leave the existing consecutive-gate path completely
untouched.

## Approach

A two-qubit gate acting on qubits `i` and `j` (non-adjacent) can be applied correctly by:

1. **Permuting** the statevector axes so that qubits `i` and `j` move to positions 0 and 1
2. **Applying** the gate normally via the existing noisy backend path, which now sees consecutive qubits at positions 0 and 1
3. **Inverting** the permutation to restore the original qubit ordering

The permutation uses `np.transpose` on the reshaped statevector tensor, which is a **zero-copy operation**, so the
overhead is negligible regardless of statevector size. This was confirmed by profiling: `permute_to_adjacent` and `permute_back` do not appear in the top 20 profiler entries.

The noise parameters are always taken from the **original** qubit indices (`q_ctr_v`, `q_trg_v`), not the permuted positions, so the physical noise model is preserved correctly.

### Why not SWAP chains?

SWAP chains bring non-consecutive qubits adjacent by inserting physical SWAP gates. This increases circuit depth, adding noise accumulation.

## Changes

### `_simulation/simulator.py` — `_preprocess_circuit`
Non-consecutive two-qubit gates are now detected during circuit preprocessing and tagged with `flag=2`, causing them to be flushed out of the current gate chunk and handled separately. Consecutive gates continue through the existing `flag=0` path unchanged.

```python
if len(q_idx) == 2 and abs(q_idx[0] - q_idx[1]) != 1:
    if current_chunk:
        data.append((current_chunk, 0))
        current_chunk = []
    data.append((op, 2))
    continue
```

### `_simulation/simulator.py` — `_single_shot`
A new `flag=2` handler applies the gate via statevector permutation:

```python
elif flag == 2:
    # Flush accumulated gates
    psi = circ.statevector(psi)
    circ.reset(phase_reset=False)
    # Permute, apply, unpermute
    psi, perm = permute_to_adjacent(psi, q_ctr_v, q_trg_v, n)
    circ.ECR(0, 1, ...)  # gate now sees consecutive qubits
    psi = circ.statevector(psi)
    circ.reset(phase_reset=False)
    psi = permute_back(psi, perm, n)
```

### `_simulation/simulations_utility.py`
Two new utility functions:

- `permute_to_adjacent(psi, q_ctr_v, q_trg_v, n)` — permutes statevector
  axes to bring target qubits to positions 0 and 1, returns permuted `psi`
  and the permutation used
- `permute_back(psi, perm, n)` — inverts the permutation to restore
  original qubit ordering


## Performance Analysis

Profiling was run on a Brisbane IBM Eagle Backend for 100 shots on a 16-qubit circuit with a single two-qubit gate, comparing three approaches:

**Note:** The non-consecutive gate test uses `cx(4,15)` on FakeBrisbane, which has an Eagle-architecture coupling map where qubits 4 and 15 are directly connected. This means the transpiler passes the gate through as a single ECR operation without inserting SWAPs, allowing the permutation path to be exercised directly. The SWAP routing comparison uses `cx(4,14)`, where qubits 4 and 14 are not directly connected, forcing the transpiler to decompose the gate into 13 ECR operations via intermediate hops.

| | Consecutive `cx(4,5)` | SWAP routing `cx(4,14)` | Permutation `cx(4,15)` |
|---|---|---|---|
| Total time | 3.12s | 14.49s | 2.69s |
| ECR gates | 1 | 13 | 1 |
| `statevector` calls | 100 | 700 | 300 |
| `tensordot` calls | 1,600 | 22,400 | 1,600 |

**The permutation approach matches consecutive gate performance (2.69s vs 3.12s) while being 4.6× faster than SWAP routing (14.49s).** The SWAP overhead is massive, routing `cx(4,14)` on FakeBrisbane requires 13 ECR gates instead of 1, causing 7× more statevector updates and 14× more tensor contractions per shot.

The permutation itself (`permute_to_adjacent`, `permute_back`) does not appear in the top 20 profiler entries in either run, confirming the axis transposition overhead is negligible at 16 qubits.

The only observable overhead in the permutation path is 3× more `statevector` calls (300 vs 100), caused by flushing the circuit before and after the non-consecutive gate. 

## Tests added

- `tests/utility/test_permute.py` — unit tests for `permute_to_adjacent` and `permute_back`
- `tests/simulation/test_non_consecutive_gates.py` — end-to-end simulator tests covering:
  - Correctness against known states
  - Equivalence with consecutive gate path
  - Noise consistency (noiseless vs noisy)
  - Full pipeline integration
- `tests/profiling.py` — profiling script comparing consecutive,
  non-consecutive via permutation, and non-consecutive via SWAP routing
